### PR TITLE
openssh-uci: add dependency to bash

### DIFF
--- a/recipes-adapters/openssh-uci/openssh-uci.bb
+++ b/recipes-adapters/openssh-uci/openssh-uci.bb
@@ -8,6 +8,8 @@ SRC_URI = " \
            file://functions.sh \
            file://uci2ssh.sh \
            "
+RDEPENDS_openssh-uci += "bash"
+
 do_install() {
     mkdir -p ${D}${sysconfdir}/config
     install -Dm 0644 ${WORKDIR}/sshd.config ${D}${sysconfdir}/config/sshd


### PR DESCRIPTION
Poky does not use bash by default. This is to fix QA check error from bitbake image build.

ERROR: openssh-uci-1.0-r0 do_package_qa: QA Issue: /usr/sbin/uci2ssh.sh contained in package openssh-uci requires /bin/bash, but no providers found in RDEPENDS_openssh-uci? [file-rdeps]
ERROR: openssh-uci-1.0-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.
ERROR: openssh-uci-1.0-r0 do_package_qa: Function failed: do_package_qa

Signed-off-by: Chang Rebecca Swee Fun <rebecca.swee.fun.chang@intel.com>