### PR TITLE
orangerpcd: add dependency to lua5.1

### DIFF
--- a/recipes-core/orangerpcd/orangerpcd_2.16.09.bb
+++ b/recipes-core/orangerpcd/orangerpcd_2.16.09.bb
@@ -21,7 +21,7 @@ S = "${WORKDIR}/git"
 inherit autotools pkgconfig
 
 DEPENDS += "libblobpack libutype libusys uci libwebsockets rpcd ubus lua5.1 luajit coreutils-native"
-RDEPENDS_${PN} += "luaposix"
+RDEPENDS_${PN} += "luaposix lua5.1"
 
 OECMAKE_C_FLAGS += "-I${STAGING_INCDIR}/lua5.1 -DLUA_COMPAT_5_1"
 CFLAGS_append = " -Wno-unused-result -Wno-implicit-fallthrough -Wno-format-truncation"


### PR DESCRIPTION
In the event of bitbake, we encountered QA Issue as shown in the logs:

ERROR: orangerpcd-2.16.09-r0 do_package_qa: QA Issue: /usr/lib/orange/api/system.lua contained in package orangerpcd requires /usr/bin/lua, but no providers found in RDEPENDS_orangerpcd? [file-rdeps]
ERROR: orangerpcd-2.16.09-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.
ERROR: orangerpcd-2.16.09-r0 do_package_qa: Function failed: do_package_qa

This is fixed by adding the dependency to lua into orangerpcd.

Signed-off-by: Chang Rebecca Swee Fun <rebecca.swee.fun.chang@intel.com>