### PR TITLE
orangerpcd: updated orange.config

### DIFF
--- a/recipes-core/orangerpcd/orangerpcd/orange.config
+++ b/recipes-core/orangerpcd/orangerpcd/orange.config
@@ -1,4 +1,11 @@
 config login {USERNAME}
-    list acls 'jcui*'
     list acls user-{USERNAME}
-
+    list acls juci-ddns
+    list acls juci-diagnostics
+    list acls juci-dropbear
+    list acls juci-ethernet
+    list acls juci-firewall-fw3
+    list acls juci-mod-status
+    list acls juci-mod-system
+    list acls juci-network-netifd
+    list acls juci


### PR DESCRIPTION
orangerpcd unable to take input juci-* hence causing orangerpcd unable to establish a connection. This configuration has been tested on runtime.

Signed-off-by: Chang Rebecca Swee Fun <rebecca.swee.fun.chang@intel.com>